### PR TITLE
Fsq-refacto

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,27 @@ xhat, indices = quantizer(x)
 assert torch.all(xhat == quantizer.indices_to_codes(indices))
 ```
 
+The possibility to not compute and return the indices, in case of out-of-memory codebook, has been added to FSQ:
+
+```python
+import torch
+from vector_quantize_pytorch import FSQ
+
+quantizer = FSQ(
+    levels = [8, 5, 5, 5],
+    return_indices = False,
+)
+
+x = torch.randn(1, 1024, 4) # 4 since there are 4 levels
+xhat, indices = quantizer(x)
+
+# (1, 1024, 4), (1, 1024)
+
+assert indices is None
+```
+
+Note that already the codebook associated to the Finite Scalar quantizer is not a parameter of the module itself.
+
 An improvised Residual FSQ, for an attempt to improve audio encoding. 
 
 Credit goes to [@sekstini](https://github.com/sekstini) for originally incepting the idea [here](https://github.com/lucidrains/vector-quantize-pytorch/pull/74#issuecomment-1742048597)

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -31,3 +31,18 @@ class TestFSQNoIndices:
         _, indices = self.quantizer(features)
 
         assert indices is None
+
+class TestFSQWithDim:
+    levels = [8,5,5,5]
+    dim = 16
+    quantizer = FSQ(levels, dim=dim)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        image_feats = torch.randn(1, 16, 32, 32)
+        quantized, indices = self.quantizer(image_feats)
+
+        assert quantized.shape == image_feats.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -32,6 +32,12 @@ class TestFSQNoIndices:
 
         assert indices is None
 
+    def test_forward_images(self):
+        image_feats = torch.randn(1, 4, 32, 32)
+        _, indices = self.quantizer(image_feats)
+
+        assert indices is None
+
 class TestFSQWithDim:
     levels = [8,5,5,5]
     dim = 16

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -18,6 +18,12 @@ class TestFSQ:
         assert quantized.shape == features.shape
         assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
 
+    def test_forward_images(self):
+        image_feats = torch.randn(1, 32, 32, 4)
+        quantized, indices = self.quantizer(image_feats)
+
+        assert quantized.shape == image_feats.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
 
 class TestFSQNoIndices:
     levels = [8,5,5,5]
@@ -33,7 +39,7 @@ class TestFSQNoIndices:
         assert indices is None
 
     def test_forward_images(self):
-        image_feats = torch.randn(1, 4, 32, 32)
+        image_feats = torch.randn(1, 32, 32, 4)
         _, indices = self.quantizer(image_feats)
 
         assert indices is None

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -38,16 +38,24 @@ class TestFSQNoIndices:
 
         assert indices is None
 
-class TestFSQWithDim:
+class TestFSQWithDimAndChannelFirst:
     levels = [8,5,5,5]
     dim = 16
-    quantizer = FSQ(levels, dim=dim)
+    quantizer = FSQ(levels, dim=dim, channel_first=True)
 
     def test_init(self):
         assert self.quantizer
 
     def test_forward(self):
-        image_feats = torch.randn(1, 16, 32, 32)
+        features = torch.randn(1, self.dim, 1024) # 4 since there are 4 levels
+        quantized, indices = self.quantizer(features)
+
+        assert quantized.shape == features.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+
+    def test_forward_images(self):
+        image_feats = torch.randn(1, self.dim, 32, 32)
         quantized, indices = self.quantizer(image_feats)
 
         assert quantized.shape == image_feats.shape

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -1,0 +1,33 @@
+import pytest
+import torch
+
+from vector_quantize_pytorch.finite_scalar_quantization import FSQ
+
+
+class TestFSQ:
+    levels = [8,5,5,5]
+    quantizer = FSQ(levels)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        features = torch.randn(1, 1024, 4) # 4 since there are 4 levels
+        quantized, indices = self.quantizer(features)
+
+        assert quantized.shape == features.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+
+class TestFSQNoIndices:
+    levels = [8,5,5,5]
+    quantizer = FSQ(levels, return_indices=False)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        features = torch.randn(1, 1024, 4) # 4 since there are 4 levels
+        _, indices = self.quantizer(features)
+
+        assert indices is None

--- a/tests/test_finite_scalar_quantization.py
+++ b/tests/test_finite_scalar_quantization.py
@@ -66,3 +66,72 @@ class TestFSQWithDimAndChannelFirst:
 
         assert quantized.shape == image_feats.shape
         assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+class TestFSQSeveralCodebooks:
+    levels = [8,5,5,5]
+    quantizer = FSQ(levels, num_codebooks=2)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        features = torch.randn(1, 1024, 8) # 4 since there are 4 levels
+        quantized, indices = self.quantizer(features)
+
+        assert quantized.shape == features.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+    def test_forward_images(self):
+        image_feats = torch.randn(1, 32, 32, 8)
+        quantized, indices = self.quantizer(image_feats)
+
+        assert quantized.shape == image_feats.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+class TestFSQSeveralCodebooksKeepCodebooks:
+    levels = [8,5,5,5]
+    num_codebooks = 2
+    quantizer = FSQ(levels, num_codebooks=num_codebooks, keep_num_codebooks_dim=True)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        features = torch.randn(1, 1024, 8) # 4 since there are 4 levels
+        quantized, indices = self.quantizer(features)
+
+        assert quantized.shape == features.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+        assert indices.shape[-1] == self.num_codebooks
+
+    def test_forward_images(self):
+        image_feats = torch.randn(1, 32, 32, 8)
+        quantized, indices = self.quantizer(image_feats)
+
+        assert quantized.shape == image_feats.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+        assert indices.shape[-1] == self.num_codebooks
+
+
+class TestFSQWithDimAndChannelFirstSeveralCodebooks:
+    levels = [8,5,5,5]
+    dim = 16
+    quantizer = FSQ(levels, dim=dim, channel_first=True, num_codebooks=2)
+
+    def test_init(self):
+        assert self.quantizer
+
+    def test_forward(self):
+        features = torch.randn(1, self.dim, 1024) # 4 since there are 4 levels
+        quantized, indices = self.quantizer(features)
+
+        assert quantized.shape == features.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))
+
+
+    def test_forward_images(self):
+        image_feats = torch.randn(1, self.dim, 32, 32)
+        quantized, indices = self.quantizer(image_feats)
+
+        assert quantized.shape == image_feats.shape
+        assert torch.all(quantized == self.quantizer.indices_to_codes(indices))

--- a/vector_quantize_pytorch/finite_scalar_quantization.py
+++ b/vector_quantize_pytorch/finite_scalar_quantization.py
@@ -4,61 +4,53 @@ Code adapted from Jax version in Appendix A.1
 """
 
 from __future__ import annotations
-from typing import List, Tuple
 
 import torch
-import torch.nn as nn
-from torch.nn import Module
-from torch import Tensor, int32
+from einops import pack, rearrange, unpack
+from torch import Tensor, int32, nn
 from torch.cuda.amp import autocast
+from torch.nn import Module
 
-from einops import rearrange, pack, unpack
-
-# helper functions
-
-def exists(v):
-    return v is not None
-
-def default(*args):
-    for arg in args:
-        if exists(arg):
-            return arg
-    return None
 
 def pack_one(t, pattern):
     return pack([t], pattern)
 
+
 def unpack_one(t, ps, pattern):
     return unpack(t, ps, pattern)[0]
 
+
 # tensor helpers
+
 
 def round_ste(z: Tensor) -> Tensor:
     """Round with straight through gradients."""
     zhat = z.round()
     return z + (zhat - z).detach()
 
+
 # main class
+
 
 class FSQ(Module):
     def __init__(
         self,
-        levels: List[int],
+        levels: list[int],
         dim: int | None = None,
-        num_codebooks = 1,
+        num_codebooks=1,
         keep_num_codebooks_dim: bool | None = None,
         scale: float | None = None,
-        allowed_dtypes: Tuple[torch.dtype, ...] = (torch.float32, torch.float64),
+        allowed_dtypes: tuple[torch.dtype, ...] = (torch.float32, torch.float64),
         channel_first: bool = False,
         projection_has_bias: bool = True,
-        return_indices = True,
+        return_indices=True,
     ):
         super().__init__()
         _levels = torch.tensor(levels, dtype=int32)
-        self.register_buffer("_levels", _levels, persistent = False)
+        self.register_buffer("_levels", _levels, persistent=False)
 
         _basis = torch.cumprod(torch.tensor([1] + levels[:-1]), dim=0, dtype=int32)
-        self.register_buffer("_basis", _basis, persistent = False)
+        self.register_buffer("_basis", _basis, persistent=False)
 
         self.scale = scale
 
@@ -69,17 +61,27 @@ class FSQ(Module):
         self.num_codebooks = num_codebooks
         self.effective_codebook_dim = effective_codebook_dim
 
-        keep_num_codebooks_dim = default(keep_num_codebooks_dim, num_codebooks > 1)
+        keep_num_codebooks_dim = (
+            keep_num_codebooks_dim if keep_num_codebooks_dim else num_codebooks > 1
+        )
         assert not (num_codebooks > 1 and not keep_num_codebooks_dim)
         self.keep_num_codebooks_dim = keep_num_codebooks_dim
 
-        self.dim = default(dim, len(_levels) * num_codebooks)
+        self.dim = dim if dim else len(_levels) * num_codebooks
 
         self.channel_first = channel_first
 
         has_projections = self.dim != effective_codebook_dim
-        self.project_in = nn.Linear(self.dim, effective_codebook_dim, bias = projection_has_bias) if has_projections else nn.Identity()
-        self.project_out = nn.Linear(effective_codebook_dim, self.dim, bias = projection_has_bias) if has_projections else nn.Identity()
+        self.project_in = (
+            nn.Linear(self.dim, effective_codebook_dim, bias=projection_has_bias)
+            if has_projections
+            else nn.Identity()
+        )
+        self.project_out = (
+            nn.Linear(effective_codebook_dim, self.dim, bias=projection_has_bias)
+            if has_projections
+            else nn.Identity()
+        )
 
         self.has_projections = has_projections
 
@@ -87,27 +89,29 @@ class FSQ(Module):
         if return_indices:
             self.codebook_size = self._levels.prod().item()
             implicit_codebook = self._indices_to_codes(torch.arange(self.codebook_size))
-            self.register_buffer("implicit_codebook", implicit_codebook, persistent = False)
+            self.register_buffer(
+                "implicit_codebook", implicit_codebook, persistent=False
+            )
 
         self.allowed_dtypes = allowed_dtypes
 
     def bound(self, z, eps: float = 1e-3):
-        """ Bound `z`, an array of shape (..., d). """
+        """Bound `z`, an array of shape (..., d)."""
         half_l = (self._levels - 1) * (1 + eps) / 2
         offset = torch.where(self._levels % 2 == 0, 0.5, 0.0)
         shift = (offset / half_l).atanh()
         return (z + shift).tanh() * half_l - offset
 
     def quantize(self, z):
-        """ Quantizes z, returns quantized zhat, same shape as z. """
+        """Quantizes z, returns quantized zhat, same shape as z."""
         quantized = round_ste(self.bound(z))
-        half_width = self._levels // 2 # Renormalize to [-1, 1].
+        half_width = self._levels // 2  # Renormalize to [-1, 1].
         return quantized / half_width
-    
+
     def _scale_and_shift(self, zhat_normalized):
         half_width = self._levels // 2
         return (zhat_normalized * half_width) + half_width
-    
+
     def _scale_and_shift_inverse(self, zhat):
         half_width = self._levels // 2
         return (zhat - half_width) / half_width
@@ -118,36 +122,35 @@ class FSQ(Module):
         return codes
 
     def codes_to_indices(self, zhat):
-        """ Converts a `code` to an index in the codebook. """
+        """Converts a `code` to an index in the codebook."""
         assert zhat.shape[-1] == self.codebook_dim
         zhat = self._scale_and_shift(zhat)
         return (zhat * self._basis).sum(dim=-1).to(int32)
 
     def indices_to_level_indices(self, indices):
-        """ Converts indices to indices at each level, perhaps needed for a transformer with factorized embeddings """
-        indices = rearrange(indices, '... -> ... 1')
+        """Converts indices to indices at each level, perhaps needed for a transformer with factorized embeddings"""
+        indices = rearrange(indices, "... -> ... 1")
         codes_non_centered = (indices // self._basis) % self._levels
         return codes_non_centered
 
     def indices_to_codes(self, indices):
-        """ Inverse of `codes_to_indices`. """
-        assert exists(indices)
+        """Inverse of `codes_to_indices`."""
 
         is_img_or_video = indices.ndim >= (3 + int(self.keep_num_codebooks_dim))
 
         codes = self._indices_to_codes(indices)
 
         if self.keep_num_codebooks_dim:
-            codes = rearrange(codes, '... c d -> ... (c d)')
+            codes = rearrange(codes, "... c d -> ... (c d)")
 
         codes = self.project_out(codes)
 
         if is_img_or_video or self.channel_first:
-            codes = rearrange(codes, 'b ... d -> b d ...')
+            codes = rearrange(codes, "b ... d -> b d ...")
 
         return codes
 
-    @autocast(enabled = False)
+    @autocast(enabled=False)
     def forward(self, z):
         """
         einstein notation
@@ -164,14 +167,16 @@ class FSQ(Module):
         # standardize image or video into (batch, seq, dimension)
 
         if need_move_channel_last:
-            z = rearrange(z, 'b d ... -> b ... d')
-            z, ps = pack_one(z, 'b * d')
+            z = rearrange(z, "b d ... -> b ... d")
+            z, ps = pack_one(z, "b * d")
 
-        assert z.shape[-1] == self.dim, f'expected dimension of {self.dim} but found dimension of {z.shape[-1]}'
+        assert (
+            z.shape[-1] == self.dim
+        ), f"expected dimension of {self.dim} but found dimension of {z.shape[-1]}"
 
         z = self.project_in(z)
 
-        z = rearrange(z, 'b n (c d) -> b n c d', c = self.num_codebooks)
+        z = rearrange(z, "b n (c d) -> b n c d", c=self.num_codebooks)
 
         # make sure allowed dtype before quantizing
 
@@ -183,7 +188,7 @@ class FSQ(Module):
         if self.return_indices:
             indices = self.codes_to_indices(codes)
 
-        codes = rearrange(codes, 'b n c d -> b n (c d)')
+        codes = rearrange(codes, "b n c d -> b n (c d)")
 
         # cast codes back to original dtype
 
@@ -197,13 +202,13 @@ class FSQ(Module):
         # reconstitute image or video dimensions
 
         if need_move_channel_last:
-            out = unpack_one(out, ps, 'b * d')
-            out = rearrange(out, 'b ... d -> b d ...')
+            out = unpack_one(out, ps, "b * d")
+            out = rearrange(out, "b ... d -> b d ...")
 
-            indices = unpack_one(indices, ps, 'b * c')
+            indices = unpack_one(indices, ps, "b * c")
 
         if not self.keep_num_codebooks_dim and self.return_indices:
-            indices = rearrange(indices, '... 1 -> ...')
+            indices = rearrange(indices, "... 1 -> ...")
 
         # return quantized output and indices
 

--- a/vector_quantize_pytorch/finite_scalar_quantization.py
+++ b/vector_quantize_pytorch/finite_scalar_quantization.py
@@ -39,7 +39,6 @@ class FSQ(Module):
         dim: int | None = None,
         num_codebooks=1,
         keep_num_codebooks_dim: bool | None = None,
-        scale: float | None = None,
         allowed_dtypes: tuple[torch.dtype, ...] = (torch.float32, torch.float64),
         channel_first: bool = False,
         projection_has_bias: bool = True,
@@ -51,8 +50,6 @@ class FSQ(Module):
 
         _basis = torch.cumprod(torch.tensor([1] + levels[:-1]), dim=0, dtype=int32)
         self.register_buffer("_basis", _basis, persistent=False)
-
-        self.scale = scale
 
         codebook_dim = len(levels)
         self.codebook_dim = codebook_dim


### PR DESCRIPTION
Here is a short PR regarding Finite Scalar Quantization, as it is implemented here. The goal is to 1) fix the bug in Issue #139 and 2) to clean the code for better ease of use.

Here are the main changes:

**Fix:**

- unpacking of `indices` when no indices are returned. 

**Remove**

- the check regarding "is the input of image-type or not?" and keeping only the attribute `channel_first` to inform the type of shapes. This is more coherent with the use of the module, and simplify the reshaping of the input of the forward pass.
- all helper functions are removed as they are not necessary and add a certain level of complexity.

**Add**

- a dedicated and (almost) complete test suite for FSQ. The tests cover almost all the code now, in particular by testing many possible choices: with or without returning indices, images or sequences input, channel first or not, several codebooks or not, and so on.
- a short paragraph and example in the README regarding the `return_indices = False` possibility.
- a as exhaustive as possible documentation of the module, the FSQ module and the methods therein. In particular, some care has been taken regarding the shape expected for the different methods.

The whole code has been properly formatted and linting.

Hope it will be reviewed :)