### PR TITLE
Parameters and api part 1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+
+
+## [Version 1.16.3]
+
+* Introduce dataclass GumbelParams for the sampling function (here, various kinds of Gumbel sampling).
+* Remove corresponding old parameters/attributes, gathered now into the new dataclass.
+* Remove the creation of the sampling function as a method in VQ, into the codebook itself.
+* Remove the definition of sample_codebook_temp inside the forward method: there is no reason now to do so.
+* Remove sample_codebook_temp as a parameter of the forward method in both VQ and Codebook classes.
+* Change accordingly the ResidualVQ class.
+
+## [Version 1.16.2]
+
+* Introduce dataclasses KmeansParams and AffineParams to gather parameters useful for only one feature.
+* Change VQ and codeooks accordingly. This allow for better readibility (dataclasses can be documented) and reduce the huge number of parameters for VQ and codebooks classes.
+* Introduce dataclasses for Codebooks Parameters. Use in VQ as a proxy for now, as the definition/declaration of both dim/codebook_dim and codebook_size is a bit more intricate.
+
 ## [Version 1.16.1]
 
 * Replace the ad-hoc 'cdist' function by the built-in torch.cdist function.

--- a/tests/test_residual_vq.py
+++ b/tests/test_residual_vq.py
@@ -1,6 +1,10 @@
 import torch
 
-from vector_quantize_pytorch.codebooks import CodebookParams, KmeansParameters
+from vector_quantize_pytorch.codebooks import (
+    CodebookParams,
+    GumbelParams,
+    KmeansParameters,
+)
 from vector_quantize_pytorch.residual_vq import GroupedResidualVQ, ResidualVQ
 
 
@@ -37,13 +41,15 @@ class TestResidualVQ2:
     num_quantizers = 3
     codebook_size = 2**5
     codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
+    gumbel_params = GumbelParams(stochastic=True)
 
     quantizer = ResidualVQ(
         dim=dim,
         num_quantizers=num_quantizers,
         codebook_size=2**5,
-        stochastic_sample_codes=True,
-        sample_codebook_temp=0.1,  # temperature for stochastically sampling codes, 0 would be equivalent to non-stochastic
+        gumbel_params=gumbel_params,
+        # stochastic_sample_codes=True,
+        # sample_codebook_temp=0.1,  # temperature for stochastically sampling codes, 0 would be equivalent to non-stochastic
         shared_codebook=True,  # whether to share the codebooks for all quantizers or not
         codebook_params=codebook_params,
     )

--- a/tests/test_residual_vq.py
+++ b/tests/test_residual_vq.py
@@ -65,7 +65,7 @@ class TestResidualVQ3:
         num_quantizers=num_quantizers,
         codebook_size=2**5,
         initialization_by_kmeans=True,  # set to True
-        kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
+        # kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
     )
 
     def test_init(self):
@@ -116,7 +116,7 @@ def test_residual_vq3():
         codebook_size=2**5,
         num_quantizers=4,
         initialization_by_kmeans=True,  # set to True
-        kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
+        # kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
     )
 
     x = torch.randn(1, 1024, 4)

--- a/tests/test_residual_vq.py
+++ b/tests/test_residual_vq.py
@@ -1,16 +1,20 @@
 import torch
 
+from vector_quantize_pytorch.codebooks import CodebookParams, KmeansParameters
 from vector_quantize_pytorch.residual_vq import GroupedResidualVQ, ResidualVQ
 
 
 class TestResidualVQ:
     dim = 4
     num_quantizers = 3
+    codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
 
     quantizer = ResidualVQ(
         dim=dim,
         num_quantizers=num_quantizers,  # specify number of quantizers
         codebook_size=2**5,  # codebook size
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -31,6 +35,8 @@ class TestResidualVQ:
 class TestResidualVQ2:
     dim = 4
     num_quantizers = 3
+    codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
 
     quantizer = ResidualVQ(
         dim=dim,
@@ -39,6 +45,7 @@ class TestResidualVQ2:
         stochastic_sample_codes=True,
         sample_codebook_temp=0.1,  # temperature for stochastically sampling codes, 0 would be equivalent to non-stochastic
         shared_codebook=True,  # whether to share the codebooks for all quantizers or not
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -59,12 +66,21 @@ class TestResidualVQ2:
 class TestResidualVQ3:
     dim = 4
     num_quantizers = 3
+    codebook_size = 2**5
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=dim,
+        codebook_size=codebook_size,
+        initialization_by_kmeans=True,
+        kmeans_params=kmeans_params,
+    )
 
     quantizer = ResidualVQ(
         dim=dim,
         num_quantizers=num_quantizers,
         codebook_size=2**5,
-        initialization_by_kmeans=True,  # set to True
+        codebook_params=codebook_params,
+        # initialization_by_kmeans=True,  # set to True
         # kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
     )
 
@@ -87,12 +103,15 @@ class TestGroupedResidualVQ:
     dim = 4
     num_quantizers = 3
     groups = 2
+    codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
 
     quantizer = GroupedResidualVQ(
         dim=dim,
         num_quantizers=num_quantizers,  # specify number of quantizers
         groups=groups,
         codebook_size=2**5,  # codebook size
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -111,11 +130,23 @@ class TestGroupedResidualVQ:
 
 
 def test_residual_vq3():
+    dim = 4
+    # num_quantizers = 3
+    codebook_size = 2**5
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=dim,
+        codebook_size=codebook_size,
+        initialization_by_kmeans=True,
+        kmeans_params=kmeans_params,
+    )
+
     quantizer = ResidualVQ(
         dim=4,
         codebook_size=2**5,
         num_quantizers=4,
-        initialization_by_kmeans=True,  # set to True
+        codebook_params=codebook_params,
+        # initialization_by_kmeans=True,  # set to True
         # kmeans_iters=10,  # number of kmeans iterations to calculate the centroids for the codebook on init
     )
 

--- a/tests/test_vector_quantize_pytorch.py
+++ b/tests/test_vector_quantize_pytorch.py
@@ -1,17 +1,20 @@
 import torch
 
 from vector_quantize_pytorch import VectorQuantize
+from vector_quantize_pytorch.codebooks import CodebookParams, KmeansParameters
 
 
 class TestVectorQuantizer:
     dim = 4
     codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
 
     quantizer = VectorQuantize(
         dim=dim,
         codebook_size=codebook_size,  # codebook size
-        decay=0.8,  # the exponential moving average decay, lower means the dictionary will change faster
+        # decay=0.8,  # the exponential moving average decay, lower means the dictionary will change faster
         commitment_weight=1.0,  # the weight on the commitment loss
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -31,13 +34,15 @@ class TestVectorQuantizer:
 class TestVectorQuantizerChannelFirst:
     dim = 4
     codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
 
     quantizer = VectorQuantize(
         dim=dim,
         codebook_size=codebook_size,  # codebook size
-        decay=0.8,  # the exponential moving average decay, lower means the dictionary will change faster
+        # decay=0.8,  # the exponential moving average decay, lower means the dictionary will change faster
         commitment_weight=1.0,  # the weight on the commitment loss
         channel_last=False,
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -55,11 +60,15 @@ class TestVectorQuantizerChannelFirst:
 
 
 class TestVectorQuantizerCosine:
+    dim = 4
+    codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
     quantizer = VectorQuantize(
         # dim=256,
         dim=4,
         codebook_size=2**5,  # codebook size
         use_cosine_sim=True,
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -78,6 +87,9 @@ class TestVectorQuantizerMultihead:
     codebook_dim = 32
     heads = 2
     dim = codebook_dim * heads
+    codebook_size = 2**5
+
+    codebook_params = CodebookParams(dim=codebook_dim, codebook_size=codebook_size)
     quantizer = VectorQuantize(
         dim=dim,
         codebook_dim=codebook_dim,  # a number of papers have shown smaller codebook dimension to be acceptable
@@ -85,6 +97,7 @@ class TestVectorQuantizerMultihead:
         separate_codebook_per_head=True,  # whether to have a separate codebook per head. False would mean 1 shared codebook
         codebook_size=2**5,
         # accept_image_fmap=True,
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -118,13 +131,21 @@ class TestVectorQuantizerMultiheadWithKmeansInit:
     codebook_dim = 32
     heads = 2
     dim = codebook_dim * heads
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=codebook_dim,
+        codebook_size=2**5,
+        initialization_by_kmeans=True,
+        kmeans_params=kmeans_params,
+    )
     quantizer = VectorQuantize(
         dim=dim,
         codebook_dim=codebook_dim,  # a number of papers have shown smaller codebook dimension to be acceptable
         heads=heads,  # number of heads to vector quantize, codebook shared across all heads
         separate_codebook_per_head=True,  # whether to have a separate codebook per head. False would mean 1 shared codebook
         codebook_size=2**5,
-        initialization_by_kmeans=True,
+        # initialization_by_kmeans=True,
+        codebook_params=codebook_params,
         # accept_image_fmap=True,
     )
 
@@ -156,10 +177,14 @@ class TestVectorQuantizerMultiheadWithKmeansInit:
 
 
 class TestVectorQuantizerLowerCode:
+    dim = 4
+    codebook_size = 2**5
+    codebook_params = CodebookParams(dim=dim, codebook_size=codebook_size)
     quantizer = VectorQuantize(
         dim=4,
         codebook_size=256,
         codebook_dim=2,  # paper proposes setting this to 32 or as low as 8 to increase codebook usage
+        codebook_params=codebook_params,
     )
 
     def test_init(self):
@@ -177,12 +202,21 @@ class TestVectorQuantizerKmeansInit:
     dim = 4
     initialization_by_kmeans = True
     codebook_size = 2**5
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=dim,
+        codebook_size=codebook_size,
+        initialization_by_kmeans=True,
+        kmeans_params=KmeansParameters(),
+    )
+
     quantizer = VectorQuantize(
         dim=4,
         codebook_size=codebook_size,
-        decay=0.8,
+        # decay=0.8,
         commitment_weight=1.0,
-        initialization_by_kmeans=initialization_by_kmeans,
+        codebook_params=codebook_params,
+        # initialization_by_kmeans=initialization_by_kmeans,
     )
 
     def test_init(self):
@@ -203,12 +237,21 @@ class TestVectorQuantizerKmeansInitWithCosine:
     dim = 4
     initialization_by_kmeans = True
     codebook_size = 2**5
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=dim,
+        codebook_size=2**5,
+        initialization_by_kmeans=True,
+        kmeans_params=kmeans_params,
+    )
+
     quantizer = VectorQuantize(
         dim=4,
         codebook_size=codebook_size,
-        decay=0.8,
+        # decay=0.8,
         commitment_weight=1.0,
-        initialization_by_kmeans=initialization_by_kmeans,
+        # initialization_by_kmeans=initialization_by_kmeans,
+        codebook_params=codebook_params,
         use_cosine_sim=True,
     )
 
@@ -230,12 +273,21 @@ class TestVectorQuantizerKmeansInitWithFewSamples:
     dim = 4
     initialization_by_kmeans = True
     codebook_size = 2**5
+    kmeans_params = KmeansParameters()
+    codebook_params = CodebookParams(
+        dim=dim,
+        codebook_size=2**5,
+        initialization_by_kmeans=True,
+        kmeans_params=kmeans_params,
+    )
+
     quantizer = VectorQuantize(
         dim=4,
         codebook_size=codebook_size,
-        decay=0.8,
+        # decay=0.8,
         commitment_weight=1.0,
-        initialization_by_kmeans=initialization_by_kmeans,
+        # initialization_by_kmeans=initialization_by_kmeans,
+        codebook_params=codebook_params,
     )
 
     def test_init(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1972,7 +1972,7 @@ wheels = [
 ]
 
 [[package]]
-name = "vector-quantize-pytorch"
+name = "vector-quantization-by-ml"
 version = "1.16.1"
 source = { editable = "." }
 dependencies = [

--- a/vector_quantize_pytorch/codebooks.py
+++ b/vector_quantize_pytorch/codebooks.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from functools import partial
 
 import torch
@@ -70,7 +70,7 @@ class CodebookParams:
     distributed_replace_codes: bool = True
     learnable_codebook: bool = False
     # gumbel_sample: Callable = gumbel_sample
-    gumbel_params: GumbelParams = GumbelParams()
+    gumbel_params: GumbelParams = field(default_factory=GumbelParams)
     # sample_codebook_temp: float = 1.0
     ema_update: bool = True
 
@@ -98,7 +98,7 @@ class CosineSimCodebookParams:
     distributed_replace_codes: bool = True
     learnable_codebook: bool = False
     # gumbel_sample: Callable = gumbel_sample
-    gumbel_params: GumbelParams = GumbelParams()
+    gumbel_params: GumbelParams = field(default_factory=GumbelParams)
     # sample_codebook_temp: float = 1.0
     ema_update: bool = True
 
@@ -148,6 +148,9 @@ class EuclideanCodebook(Module):
 
         # assert callable(gumbel_sample)
         # self.gumbel_sample = gumbel_sample
+        print(
+            f"DEBUG ::: gumbel_params is of type {type(gumbel_params)} and its contents are {gumbel_params}"
+        )
         self.sample_fn_training = partial(gumbel_sample, **asdict(gumbel_params))
         # self.sample_codebook_temp = sample_codebook_temp
         # gumbel_params_val = gumbel_params

--- a/vector_quantize_pytorch/codebooks.py
+++ b/vector_quantize_pytorch/codebooks.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from functools import partial
 
 import torch
@@ -27,6 +28,23 @@ from vector_quantize_pytorch.utils.kmeans import kmeans
 from vector_quantize_pytorch.utils.losses import l2norm
 
 
+@dataclass
+class AffineParameters:
+    """Dataclass gathering parameters for affine update."""
+
+    sync: bool
+    batch_decay: float = 0.99
+    codebook_decay: float = 0.9
+
+
+@dataclass
+class KmeansParameters:
+    """Dataclass gathering parameters for Kmeans algorithm."""
+
+    iter: int = 10
+    sync: bool = True
+
+
 class EuclideanCodebook(Module):
     def __init__(
         self,
@@ -34,10 +52,9 @@ class EuclideanCodebook(Module):
         codebook_size,
         num_codebooks=1,
         initialization_by_kmeans: bool = False,
-        kmeans_iters: int = 10,
-        sync_kmeans=True,
+        kmeans_params: KmeansParameters = None,
         decay=0.8,
-        eps=1e-5,
+        eps_for_smoothing=1e-5,
         threshold_ema_dead_code=2,
         reset_cluster_size=None,
         use_ddp=False,
@@ -46,10 +63,8 @@ class EuclideanCodebook(Module):
         gumbel_sample=gumbel_sample,
         sample_codebook_temp=1.0,
         ema_update=True,
-        affine_param=False,
-        sync_affine_param=False,
-        affine_param_batch_decay=0.99,
-        affine_param_codebook_decay=0.9,
+        use_affine=False,
+        affine_params: AffineParameters = None,
     ):
         super().__init__()
         self.transform_input = identity
@@ -63,10 +78,9 @@ class EuclideanCodebook(Module):
         self.codebook_size = codebook_size
         self.num_codebooks = num_codebooks
 
-        self.kmeans_iters = kmeans_iters
-        self.eps = eps
+        self.kmeans_params = kmeans_params
+        self.eps_for_smoothing = eps_for_smoothing
         self.threshold_ema_dead_code = threshold_ema_dead_code
-        # self.reset_cluster_size = default(reset_cluster_size, threshold_ema_dead_code)
         self.reset_cluster_size = (
             reset_cluster_size
             if reset_cluster_size is not None
@@ -83,19 +97,19 @@ class EuclideanCodebook(Module):
 
         self.sample_fn = (
             sample_vectors_distributed
-            if use_ddp and sync_kmeans
+            if use_ddp and self.kmeans_params.sync
             else batched_sample_vectors
         )
 
         self.distributed_replace_codes = distributed_replace_codes
         self.replace_sample_fn = (
             sample_vectors_distributed
-            if use_ddp and sync_kmeans and distributed_replace_codes
+            if use_ddp and self.kmeans_params.sync and distributed_replace_codes
             else batched_sample_vectors
         )
 
         self.kmeans_all_reduce_fn = (
-            distributed.all_reduce if use_ddp and sync_kmeans else noop
+            distributed.all_reduce if use_ddp and self.kmeans_params.sync else noop
         )
         self.all_reduce_fn = distributed.all_reduce if use_ddp else noop
 
@@ -112,14 +126,8 @@ class EuclideanCodebook(Module):
 
         # affine related params
 
-        self.affine_param = affine_param
-        self.sync_affine_param = sync_affine_param
-
-        if not affine_param:
-            return
-
-        self.affine_param_batch_decay = affine_param_batch_decay
-        self.affine_param_codebook_decay = affine_param_codebook_decay
+        self.use_affine = use_affine
+        self.affine_params = affine_params
 
         self.register_buffer("batch_mean", None)
         self.register_buffer("batch_variance", None)
@@ -138,7 +146,7 @@ class EuclideanCodebook(Module):
         embeddings, cluster_size = kmeans(
             data,
             num_clusters=self.codebook_size,
-            num_iters=self.kmeans_iters,
+            num_iters=self.kmeans_params.iter,
             sample_fn=self.sample_fn,
             all_reduce_fn=self.kmeans_all_reduce_fn,
         )
@@ -169,7 +177,7 @@ class EuclideanCodebook(Module):
 
     @torch.jit.ignore
     def update_affine(self, data, embeddings, mask=None):
-        assert self.affine_param
+        assert self.use_affine
 
         var_fn = partial(torch.var, unbiased=False)
 
@@ -181,12 +189,12 @@ class EuclideanCodebook(Module):
             self.update_with_decay(
                 "codebook_mean",
                 reduce(embeddings, "h n d -> h 1 d", "mean"),
-                self.affine_param_codebook_decay,
+                self.affine_params.codebook_decay,
             )
             self.update_with_decay(
                 "codebook_variance",
                 reduce(embeddings, "h n d -> h 1 d", var_fn),
-                self.affine_param_codebook_decay,
+                self.affine_params.codebook_decay,
             )
 
         # prepare batch data, which depends on whether it has masking
@@ -199,16 +207,16 @@ class EuclideanCodebook(Module):
 
         # calculate batch mean and variance
 
-        if not self.sync_affine_param:
+        if not self.affine_params.sync:
             self.update_with_decay(
                 "batch_mean",
                 reduce(data, "h n d -> h 1 d", "mean"),
-                self.affine_param_batch_decay,
+                self.affine_params.batch_decay,
             )
             self.update_with_decay(
                 "batch_variance",
                 reduce(data, "h n d -> h 1 d", var_fn),
-                self.affine_param_batch_decay,
+                self.affine_params.batch_decay,
             )
             return
 
@@ -225,7 +233,11 @@ class EuclideanCodebook(Module):
         distributed.all_reduce(batch_sum)
         batch_mean = batch_sum / num_vectors
 
-        self.update_with_decay("batch_mean", batch_mean, self.affine_param_batch_decay)
+        self.update_with_decay(
+            "batch_mean",
+            batch_mean,
+            self.affine_params.batch_decay,
+        )
 
         # calculate distributed variance
 
@@ -234,7 +246,9 @@ class EuclideanCodebook(Module):
         batch_variance = variance_numer / num_vectors
 
         self.update_with_decay(
-            "batch_variance", batch_variance, self.affine_param_batch_decay
+            "batch_variance",
+            batch_variance,
+            self.affine_params.batch_decay,
         )
 
     def replace(self, batch_samples, batch_mask):
@@ -266,7 +280,6 @@ class EuclideanCodebook(Module):
     @autocast(enabled=False)
     def forward(self, x, sample_codebook_temp=None, mask=None, freeze_codebook=False):
         needs_codebook_dim = x.ndim < 4
-        # sample_codebook_temp = default(sample_codebook_temp, self.sample_codebook_temp)
         sample_codebook_temp = (
             sample_codebook_temp
             if sample_codebook_temp is not None
@@ -277,7 +290,6 @@ class EuclideanCodebook(Module):
         if needs_codebook_dim:
             x = rearrange(x, "... -> 1 ...")
 
-        # dtype = x.dtype
         flatten, ps = pack_one(x, "h * d")
 
         if mask is not None:
@@ -291,14 +303,14 @@ class EuclideanCodebook(Module):
             self.initialize_embeddings(flatten, mask=mask)
             self.is_initialized = True
 
-        if self.affine_param:
+        if self.use_affine:
             self.update_affine(flatten, self.embeddings, mask=mask)
 
         embeddings = (
             self.embeddings if self.learnable_codebook else self.embeddings.detach()
         )
 
-        if self.affine_param:
+        if self.use_affine:
             codebook_std = self.codebook_variance.clamp(min=1e-5).sqrt()
             batch_std = self.batch_variance.clamp(min=1e-5).sqrt()
             embeddings = (embeddings - self.codebook_mean) * (
@@ -320,7 +332,7 @@ class EuclideanCodebook(Module):
             quantize = batched_embedding(embed_ind, embeddings)
 
         if self.training and self.ema_update and not freeze_codebook:
-            if self.affine_param:
+            if self.use_affine:
                 flatten = (flatten - self.batch_mean) * (
                     codebook_std / batch_std
                 ) + self.codebook_mean
@@ -340,7 +352,7 @@ class EuclideanCodebook(Module):
             ema_inplace(self.embed_avg.data, embed_sum, self.decay)
 
             cluster_size = laplace_smoothing(
-                self.cluster_size, self.codebook_size, self.eps
+                self.cluster_size, self.codebook_size, self.eps_for_smoothing
             ) * self.cluster_size.sum(dim=-1, keepdim=True)
 
             embed_normalized = self.embed_avg / rearrange(cluster_size, "... -> ... 1")
@@ -364,10 +376,9 @@ class CosineSimCodebook(Module):
         codebook_size,
         num_codebooks=1,
         initialization_by_kmeans=False,
-        kmeans_iters=10,
-        sync_kmeans=True,
+        kmeans_params: KmeansParameters = None,
         decay=0.8,
-        eps=1e-5,
+        eps_for_smoothing=1e-5,
         threshold_ema_dead_code=2,
         reset_cluster_size=None,
         use_ddp=False,
@@ -391,10 +402,9 @@ class CosineSimCodebook(Module):
         self.codebook_size = codebook_size
         self.num_codebooks = num_codebooks
 
-        self.kmeans_iters = kmeans_iters
-        self.eps = eps
+        self.kmeans_params = kmeans_params
+        self.eps_for_smoothing = eps_for_smoothing
         self.threshold_ema_dead_code = threshold_ema_dead_code
-        # self.reset_cluster_size = default(reset_cluster_size, threshold_ema_dead_code)
         self.reset_cluster_size = (
             reset_cluster_size
             if reset_cluster_size is not None
@@ -407,23 +417,22 @@ class CosineSimCodebook(Module):
 
         self.sample_fn = (
             sample_vectors_distributed
-            if use_ddp and sync_kmeans
+            if use_ddp and self.kmeans_params.sync
             else batched_sample_vectors
         )
 
         self.distributed_replace_codes = distributed_replace_codes
         self.replace_sample_fn = (
             sample_vectors_distributed
-            if use_ddp and sync_kmeans and distributed_replace_codes
+            if use_ddp and self.kmeans_params.sync and distributed_replace_codes
             else batched_sample_vectors
         )
 
         self.kmeans_all_reduce_fn = (
-            distributed.all_reduce if use_ddp and sync_kmeans else noop
+            distributed.all_reduce if use_ddp and self.kmeans_params.sync else noop
         )
         self.all_reduce_fn = distributed.all_reduce if use_ddp else noop
 
-        # self.register_buffer("is_initialized", torch.Tensor([not initialization_by_kmeans]))
         self.is_initialized = not initialization_by_kmeans
         self.register_buffer("cluster_size", torch.zeros(num_codebooks, codebook_size))
         self.register_buffer("embed_avg", embeddings.clone())
@@ -443,7 +452,7 @@ class CosineSimCodebook(Module):
         embeddings, cluster_size = kmeans(
             data,
             self.codebook_size,
-            self.kmeans_iters,
+            self.kmeans_params.iter,
             use_cosine_sim=True,
             sample_fn=self.sample_fn,
             all_reduce_fn=self.kmeans_all_reduce_fn,
@@ -454,7 +463,6 @@ class CosineSimCodebook(Module):
         self.embeddings.data.copy_(embeddings)
         self.embed_avg.data.copy_(embed_sum)
         self.cluster_size.data.copy_(cluster_size)
-        # self.is_initialized.data.copy_(torch.Tensor([True]))
 
     def replace(self, batch_samples, batch_mask):
         batch_samples = l2norm(batch_samples)
@@ -487,7 +495,6 @@ class CosineSimCodebook(Module):
     @autocast(enabled=False)
     def forward(self, x, sample_codebook_temp=None, mask=None, freeze_codebook=False):
         needs_codebook_dim = x.ndim < 4
-        # sample_codebook_temp = default(sample_codebook_temp, self.sample_codebook_temp)
         sample_codebook_temp = (
             sample_codebook_temp
             if sample_codebook_temp is not None
@@ -498,8 +505,6 @@ class CosineSimCodebook(Module):
 
         if needs_codebook_dim:
             x = rearrange(x, "... -> 1 ...")
-
-        # dtype = x.dtype
 
         flatten, ps = pack_one(x, "h * d")
 
@@ -548,7 +553,7 @@ class CosineSimCodebook(Module):
             ema_inplace(self.embed_avg.data, embed_sum, self.decay)
 
             cluster_size = laplace_smoothing(
-                self.cluster_size, self.codebook_size, self.eps
+                self.cluster_size, self.codebook_size, self.eps_for_smoothing
             ) * self.cluster_size.sum(dim=-1, keepdim=True)
 
             embed_normalized = self.embed_avg / rearrange(cluster_size, "... -> ... 1")

--- a/vector_quantize_pytorch/codebooks.py
+++ b/vector_quantize_pytorch/codebooks.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
+from typing import Callable
 
 import torch
 from einops import rearrange, reduce, repeat
@@ -45,6 +46,52 @@ class KmeansParameters:
     sync: bool = True
 
 
+@dataclass
+class CodebookParams:
+    dim: int
+    codebook_size: int
+    num_codebooks: int = 1
+    initialization_by_kmeans: bool = False
+    kmeans_params: KmeansParameters = None
+    decay: float = 0.8
+    eps_for_smoothing: float = 1e-5
+    threshold_ema_dead_code: int = 2
+    reset_cluster_size: int = None
+    use_ddp: bool = False
+    distributed_replace_codes: bool = True
+    learnable_codebook: bool = False
+    gumbel_sample: Callable = gumbel_sample
+    sample_codebook_temp: float = 1.0
+    ema_update: bool = True
+
+
+@dataclass
+class EuclideanCodebookParams(CodebookParams):
+    """A dataclass which wraps all parameters necessary for EuclideanCodebook."""
+
+    use_affine: bool = False
+    affine_params: AffineParameters = None
+
+
+@dataclass
+class CosineSimCodebookParams:
+    dim: int
+    codebook_size: int
+    num_codebooks: int = 1
+    initialization_by_kmeans: bool = False
+    kmeans_params: KmeansParameters = None
+    decay: float = 0.8
+    eps_for_smoothing: float = 1e-5
+    threshold_ema_dead_code: int = 2
+    reset_cluster_size: int = None
+    use_ddp: bool = False
+    distributed_replace_codes: bool = True
+    learnable_codebook: bool = False
+    gumbel_sample: Callable = gumbel_sample
+    sample_codebook_temp: float = 1.0
+    ema_update: bool = True
+
+
 class EuclideanCodebook(Module):
     def __init__(
         self,
@@ -53,17 +100,17 @@ class EuclideanCodebook(Module):
         num_codebooks=1,
         initialization_by_kmeans: bool = False,
         kmeans_params: KmeansParameters = None,
-        decay=0.8,
-        eps_for_smoothing=1e-5,
-        threshold_ema_dead_code=2,
-        reset_cluster_size=None,
-        use_ddp=False,
-        distributed_replace_codes=True,
-        learnable_codebook=False,
-        gumbel_sample=gumbel_sample,
-        sample_codebook_temp=1.0,
-        ema_update=True,
-        use_affine=False,
+        decay: float = 0.8,
+        eps_for_smoothing: float = 1e-5,
+        threshold_ema_dead_code: int = 2,
+        reset_cluster_size: int = None,
+        use_ddp: bool = False,
+        distributed_replace_codes: bool = True,
+        learnable_codebook: bool = False,
+        gumbel_sample: Callable = gumbel_sample,
+        sample_codebook_temp: float = 1.0,
+        ema_update: bool = True,
+        use_affine: bool = False,
         affine_params: AffineParameters = None,
     ):
         super().__init__()
@@ -372,21 +419,21 @@ class EuclideanCodebook(Module):
 class CosineSimCodebook(Module):
     def __init__(
         self,
-        dim,
-        codebook_size,
-        num_codebooks=1,
-        initialization_by_kmeans=False,
+        dim: int,
+        codebook_size: int,
+        num_codebooks: int = 1,
+        initialization_by_kmeans: bool = False,
         kmeans_params: KmeansParameters = None,
-        decay=0.8,
-        eps_for_smoothing=1e-5,
-        threshold_ema_dead_code=2,
-        reset_cluster_size=None,
-        use_ddp=False,
-        distributed_replace_codes=True,
-        learnable_codebook=False,
-        gumbel_sample=gumbel_sample,
-        sample_codebook_temp=1.0,
-        ema_update=True,
+        decay: float = 0.8,
+        eps_for_smoothing: float = 1e-5,
+        threshold_ema_dead_code: int = 2,
+        reset_cluster_size: int = None,
+        use_ddp: bool = False,
+        distributed_replace_codes: bool = True,
+        learnable_codebook: bool = False,
+        gumbel_sample: Callable = gumbel_sample,
+        sample_codebook_temp: float = 1.0,
+        ema_update: bool = True,
     ):
         super().__init__()
         self.transform_input = l2norm

--- a/vector_quantize_pytorch/residual_vq.py
+++ b/vector_quantize_pytorch/residual_vq.py
@@ -144,7 +144,7 @@ class ResidualVQ(Module):
         mask=None,
         indices: Tensor | list[Tensor] | None = None,
         return_all_codes=False,
-        sample_codebook_temp=None,
+        # sample_codebook_temp=None,
         freeze_codebook=False,
         rand_quantize_dropout_fixed_seed=None,
     ):
@@ -234,7 +234,7 @@ class ResidualVQ(Module):
                 residual,
                 mask=mask,
                 indices=layer_indices,
-                sample_codebook_temp=sample_codebook_temp,
+                # sample_codebook_temp=sample_codebook_temp,
                 freeze_codebook=freeze_codebook,
             )
 
@@ -324,7 +324,7 @@ class GroupedResidualVQ(Module):
         x,
         indices=None,
         return_all_codes=False,
-        sample_codebook_temp=None,
+        # sample_codebook_temp=None,
         freeze_codebook=False,
         mask=None,
     ):
@@ -343,7 +343,7 @@ class GroupedResidualVQ(Module):
 
         forward_kwargs = dict(
             return_all_codes=return_all_codes,
-            sample_codebook_temp=sample_codebook_temp,
+            # sample_codebook_temp=sample_codebook_temp,
             mask=mask,
             freeze_codebook=freeze_codebook,
             rand_quantize_dropout_fixed_seed=random.randint(0, int(1e7)),

--- a/vector_quantize_pytorch/vector_quantize_pytorch.py
+++ b/vector_quantize_pytorch/vector_quantize_pytorch.py
@@ -49,7 +49,7 @@ class VectorQuantize(Module):
         heads=1,
         separate_codebook_per_head=False,
         decay=0.8,
-        eps=1e-5,
+        eps_for_smoothing=1e-5,
         initialization_by_kmeans=False,
         kmeans_params: KmeansParameters = KmeansParameters(),
         use_cosine_sim=False,
@@ -104,11 +104,13 @@ class VectorQuantize(Module):
 
         self.has_projections = requires_projection
 
-        self.eps = eps
+        self.eps_for_smoothing = eps_for_smoothing
 
         self.has_commitment_loss = commitment_weight > 0.0
         self.commitment_weight = commitment_weight
         self.commitment_use_cross_entropy_loss = commitment_use_cross_entropy_loss  # whether to use cross entropy loss to codebook as commitment loss
+
+        # self.codebook_params = codebook_params
 
         self.learnable_codebook = learnable_codebook
 
@@ -153,7 +155,7 @@ class VectorQuantize(Module):
             initialization_by_kmeans=initialization_by_kmeans,
             kmeans_params=kmeans_params,
             decay=decay,
-            eps=eps,
+            eps_for_smoothing=eps_for_smoothing,
             threshold_ema_dead_code=threshold_ema_dead_code,
             use_ddp=sync_codebook,
             learnable_codebook=has_codebook_orthogonal_loss or learnable_codebook,


### PR DESCRIPTION
This is another step towards a simpler, cleaner API for the VectorQuantizer.

## [Version 1.16.3]

* Introduce dataclass GumbelParams for the sampling function (here, various kinds of Gumbel sampling).
* Remove corresponding old parameters/attributes, gathered now into the new dataclass.
* Remove the creation of the sampling function as a method in VQ, into the codebook itself.
* Remove the definition of sample_codebook_temp inside the forward method: there is no reason now to do so.
* Remove sample_codebook_temp as a parameter of the forward method in both VQ and Codebook classes.
* Change accordingly the ResidualVQ class.

## [Version 1.16.2]

* Introduce dataclasses KmeansParams and AffineParams to gather parameters useful for only one feature.
* Change VQ and codeooks accordingly. This allow for better readibility (dataclasses can be documented) and reduce the huge number of parameters for VQ and codebooks classes.
* Introduce dataclasses for Codebooks Parameters. Use in VQ as a proxy for now, as the definition/declaration of both dim/codebook_dim and codebook_size is a bit more intricate.